### PR TITLE
Fix #275: Encode transaction_data_hashes as base64url in key binding JWT

### DIFF
--- a/Sources/eudiWalletOidcIos/Service/Verification/AuthrizationResponse/VPTokenBuilders/SDJWTVpTokenBuilder.swift
+++ b/Sources/eudiWalletOidcIos/Service/Verification/AuthrizationResponse/VPTokenBuilders/SDJWTVpTokenBuilder.swift
@@ -83,10 +83,13 @@ class SDJWTVpTokenBuilder : VpTokenBuilder{
     
     func generateHash(input: String) -> String? {
         guard let data = input.data(using: .utf8) else { return nil }
-        
+
         let hash = Data(SHA256.hash(data: data))
-        
-        return hash.map { String(format: "%02x", $0) }.joined()
+
+        // Per OpenID4VP "A profile of Transaction Data", transaction_data_hashes
+        // are base64url-encoded (no padding) SHA-256 over the original
+        // base64url-encoded transaction_data value.
+        return hash.urlSafeBase64EncodedString()
     }
     
 }


### PR DESCRIPTION
Per OpenID4VP "A profile of Transaction Data", each entry intransaction_data_hashes MUST be a base64url-encoded (no padding) SHA-256 hash of the original base64url-encoded transaction_data value. The previous implementation emitted the hash as a hex string.