### PR TITLE
Fix #332: Send the whole x5c chain in the trust-list lookup

### DIFF
--- a/Sources/eudiWalletOidcIos/Service/TrustService/ServerTrustMechanismService.swift
+++ b/Sources/eudiWalletOidcIos/Service/TrustService/ServerTrustMechanismService.swift
@@ -56,7 +56,17 @@ public class ServerTrustMechanismService: TrustMechanismServiceProtocol {
                                           x5c: String?,
                                           jwksURI: String?,
                                           completion: @escaping (Bool?) -> Void) {
-        lookup(identifier: x5c) { response in
+        isIssuerOrVerifierTrusted(url: url, data: data, x5c: x5c, x5cChain: nil,
+                                  jwksURI: jwksURI, completion: completion)
+    }
+
+    public func isIssuerOrVerifierTrusted(url: String?,
+                                          data: TrustServiceStatusList? = nil,
+                                          x5c: String?,
+                                          x5cChain: [String]?,
+                                          jwksURI: String?,
+                                          completion: @escaping (Bool?) -> Void) {
+        lookup(identifier: x5c, chain: x5cChain) { response in
             // Return true on match, nil otherwise — matches TrustMechanismService's semantics so
             // callers (e.g. FilterCredentialService) can `.contains(true)`. A match whose services
             // are all withdrawn is not trusted.
@@ -70,7 +80,17 @@ public class ServerTrustMechanismService: TrustMechanismServiceProtocol {
                                   x5c: String?,
                                   jwksURI: String?,
                                   completion: @escaping (TrustServiceProvider?) -> Void) {
-        lookup(identifier: x5c) { response in
+        fetchTrustDetails(url: url, data: data, x5c: x5c, x5cChain: nil,
+                          jwksURI: jwksURI, completion: completion)
+    }
+
+    public func fetchTrustDetails(url: String?,
+                                  data: TrustServiceStatusList? = nil,
+                                  x5c: String?,
+                                  x5cChain: [String]?,
+                                  jwksURI: String?,
+                                  completion: @escaping (TrustServiceProvider?) -> Void) {
+        lookup(identifier: x5c, chain: x5cChain) { response in
             guard let response = response, response.match else {
                 completion(nil)
                 return
@@ -120,15 +140,31 @@ public class ServerTrustMechanismService: TrustMechanismServiceProtocol {
     ///
     /// Every lookup is logged with the input it was given — which identifier kind was sent and the
     /// (abbreviated) value — so a trust decision can always be traced back to what was asked.
-    private func lookup(identifier: String?, completion: @escaping (TrustListLookupResponse?) -> Void) {
-        guard let identifier = identifier, !identifier.isEmpty,
-              let url = URL(string: lookupURL) else {
+    /// - Parameter chain: the request's full certificate chain, **leaf first** (a JWS `x5c` header or
+    ///   a COSE `x5chain`). When present it is posted whole, so the backend can match an entry
+    ///   registered against the CA or an intermediate rather than the leaf, and report which one hit
+    ///   via `matchedCertIndex`. Otherwise the single `identifier` is routed to the field its shape
+    ///   implies (x5c / did / kid).
+    private func lookup(identifier: String?,
+                        chain: [String]? = nil,
+                        completion: @escaping (TrustListLookupResponse?) -> Void) {
+        let certChain = (chain ?? []).filter { !$0.isEmpty }
+        guard let url = URL(string: lookupURL),
+              !certChain.isEmpty || !(identifier ?? "").isEmpty else {
             print("TrustLookup ▶︎ SKIPPED — no identifier supplied (failing closed)")
             completion(nil)
             return
         }
+        // Keep the log's `value` meaningful even when only a chain was supplied.
+        let identifier = (identifier?.isEmpty == false) ? identifier! : certChain[0]
 
-        let body = buildLookupBody(identifier: identifier)
+        let body: TrustListLookupRequest
+        if certChain.isEmpty {
+            body = buildLookupBody(identifier: identifier)
+        } else {
+            print("TrustLookup ▶︎ by x5c chain of \(certChain.count) certificate(s), leaf first")
+            body = TrustListLookupRequest(x5c: certChain)
+        }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Sources/eudiWalletOidcIos/Service/TrustService/TrustMechanismServiceProtocol.swift
+++ b/Sources/eudiWalletOidcIos/Service/TrustService/TrustMechanismServiceProtocol.swift
@@ -8,8 +8,31 @@
 import Foundation
 
 protocol TrustMechanismServiceProtocol {
-    
+
     func isIssuerOrVerifierTrusted(url: String?, data: TrustServiceStatusList?, x5c: String?, jwksURI: String?, completion: @escaping (Bool?) -> Void)
-    
+
     func fetchTrustDetails(url: String?, data: TrustServiceStatusList?, x5c: String?, jwksURI: String?, completion: @escaping (TrustServiceProvider?) -> Void)
+
+    /// Same lookups, given the request's full certificate chain — **leaf first**, as it appears in a
+    /// JWS `x5c` header or a COSE `x5chain`. Supply this whenever the request carries more than the
+    /// signing certificate: a trust list may register the CA or an intermediate rather than the leaf,
+    /// and only a lookup that sees the whole chain can match such an entry.
+    func isIssuerOrVerifierTrusted(url: String?, data: TrustServiceStatusList?, x5c: String?, x5cChain: [String]?, jwksURI: String?, completion: @escaping (Bool?) -> Void)
+
+    /// See `isIssuerOrVerifierTrusted(url:data:x5c:x5cChain:jwksURI:completion:)`.
+    func fetchTrustDetails(url: String?, data: TrustServiceStatusList?, x5c: String?, x5cChain: [String]?, jwksURI: String?, completion: @escaping (TrustServiceProvider?) -> Void)
+}
+
+/// A chain is only meaningful to an implementation that forwards it to a backend. The local/static
+/// TSL implementation matches certificates one at a time, so it inherits these: the chain is
+/// dropped and the leaf identifier is used, exactly as before.
+extension TrustMechanismServiceProtocol {
+
+    func isIssuerOrVerifierTrusted(url: String?, data: TrustServiceStatusList?, x5c: String?, x5cChain: [String]?, jwksURI: String?, completion: @escaping (Bool?) -> Void) {
+        isIssuerOrVerifierTrusted(url: url, data: data, x5c: x5c ?? x5cChain?.first, jwksURI: jwksURI, completion: completion)
+    }
+
+    func fetchTrustDetails(url: String?, data: TrustServiceStatusList?, x5c: String?, x5cChain: [String]?, jwksURI: String?, completion: @escaping (TrustServiceProvider?) -> Void) {
+        fetchTrustDetails(url: url, data: data, x5c: x5c ?? x5cChain?.first, jwksURI: jwksURI, completion: completion)
+    }
 }


### PR DESCRIPTION
A trust list may register an organisation by its CA or an intermediate rather than by the signing certificate, so a lookup that only ever sees the leaf cannot match such an entry and a listed verifier resolves as untrusted.

Add an x5cChain parameter (leaf first) to fetchTrustDetails and isIssuerOrVerifierTrusted. When supplied, the chain is posted whole and the backend reports which link matched via matchedCertIndex, which the response model already reads; otherwise the single identifier is routed to the field its shape implies (x5c / kid / did), exactly as before.

TrustListLookupRequest needed no change — its x5c field was already an array that only ever carried one element.

The existing signatures stay and forward with x5cChain nil, so no current caller changes behaviour. On the protocol the two chain methods come with a default implementation that drops the chain and uses the leaf, so the local/static TSL implementation is untouched.

Counterpart of the same change in the Android SDK.